### PR TITLE
react-redux: Compat with React 19 types

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@testing-library/react": "^14.1.2",
     "@testing-library/react-hooks": "^8.0.1",
     "@types/node": "^20.11.6",
+    "@types/prop-types": "^15.7.12",
     "@types/react": "npm:types-react@19.0.0-alpha.2",
     "@typescript-eslint/eslint-plugin": "^6.17.0",
     "@typescript-eslint/parser": "^6.17.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@testing-library/react": "^14.1.2",
     "@testing-library/react-hooks": "^8.0.1",
     "@types/node": "^20.11.6",
-    "@types/react": "18.2.25",
+    "@types/react": "npm:types-react@19.0.0-alpha.2",
     "@typescript-eslint/eslint-plugin": "^6.17.0",
     "@typescript-eslint/parser": "^6.17.0",
     "babel-eslint": "^10.1.0",
@@ -109,6 +109,10 @@
     "tsup": "^7.0.0",
     "typescript": "^5.4.2",
     "vitest": "^1.2.1"
+  },
+  "resolutions": {
+    "@types/react": "npm:types-react@19.0.0-alpha.2",
+    "@types/react-dom": "npm:types-react-dom@19.0.0-alpha.2"
   },
   "packageManager": "yarn@4.1.0"
 }

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -641,13 +641,13 @@ function connect<
       }, [didStoreComeFromProps, contextValue, subscription])
 
       // Set up refs to coordinate values between the subscription effect and the render logic
-      const lastChildProps = React.useRef<unknown>()
+      const lastChildProps = React.useRef<unknown>(undefined)
       const lastWrapperProps = React.useRef(wrapperProps)
-      const childPropsFromStoreUpdate = React.useRef<unknown>()
+      const childPropsFromStoreUpdate = React.useRef<unknown>(undefined)
       const renderIsScheduled = React.useRef(false)
       const isMounted = React.useRef(false)
 
-      const latestSubscriptionCallbackError = React.useRef<Error>()
+      const latestSubscriptionCallbackError = React.useRef<Error>(undefined)
 
       useIsomorphicLayoutEffect(() => {
         isMounted.current = true
@@ -752,11 +752,11 @@ function connect<
       const renderedWrappedComponent = React.useMemo(() => {
         return (
           // @ts-ignore
-          <WrappedComponent
+          (<WrappedComponent
             {...actualChildProps}
             ref={reactReduxForwardedRef}
-          />
-        )
+          />)
+        );
       }, [reactReduxForwardedRef, WrappedComponent, actualChildProps])
 
       // If React sees the exact same element reference as last time, it bails out of re-rendering

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -752,11 +752,11 @@ function connect<
       const renderedWrappedComponent = React.useMemo(() => {
         return (
           // @ts-ignore
-          (<WrappedComponent
+          <WrappedComponent
             {...actualChildProps}
             ref={reactReduxForwardedRef}
-          />)
-        );
+          />
+        )
       }, [reactReduxForwardedRef, WrappedComponent, actualChildProps])
 
       // If React sees the exact same element reference as last time, it bails out of re-rendering

--- a/test/components/Provider.spec.tsx
+++ b/test/components/Provider.spec.tsx
@@ -1,7 +1,7 @@
 /*eslint-disable react/prop-types*/
 
 import * as rtl from '@testing-library/react'
-import type { Dispatch } from 'react'
+import type { Dispatch, JSX } from 'react';
 import React, { Component } from 'react'
 import type { Store } from 'redux'
 import { createStore } from 'redux'

--- a/test/components/Provider.spec.tsx
+++ b/test/components/Provider.spec.tsx
@@ -1,7 +1,7 @@
 /*eslint-disable react/prop-types*/
 
 import * as rtl from '@testing-library/react'
-import type { Dispatch, JSX } from 'react';
+import type { Dispatch, JSX } from 'react'
 import React, { Component } from 'react'
 import type { Store } from 'redux'
 import { createStore } from 'redux'

--- a/test/components/connect.spec.tsx
+++ b/test/components/connect.spec.tsx
@@ -1,7 +1,7 @@
 /*eslint-disable react/prop-types*/
 
 import * as rtl from '@testing-library/react'
-import type { Dispatch, ElementType, MouseEvent, ReactNode, JSX } from 'react';
+import type { Dispatch, ElementType, MouseEvent, ReactNode, JSX } from 'react'
 import React, { Component } from 'react'
 import type {
   Action,

--- a/test/components/connect.spec.tsx
+++ b/test/components/connect.spec.tsx
@@ -1,7 +1,7 @@
 /*eslint-disable react/prop-types*/
 
 import * as rtl from '@testing-library/react'
-import type { Dispatch, ElementType, MouseEvent, ReactNode } from 'react'
+import type { Dispatch, ElementType, MouseEvent, ReactNode, JSX } from 'react';
 import React, { Component } from 'react'
 import type {
   Action,

--- a/test/typetests/connect-options-and-issues.tsx
+++ b/test/typetests/connect-options-and-issues.tsx
@@ -810,6 +810,7 @@ function testRef() {
   ;<ConnectedClassComponent
     ref={(ref: ClassComponent) => {}}
   ></ConnectedClassComponent>
+  // @ts-expect-error String refs are no longer supported in React 19.
   ;<ConnectedClassComponent ref={''}></ConnectedClassComponent>
   // ref type should be the typeof the wrapped component
   ;<ConnectedClassComponent

--- a/test/typetests/connect-options-and-issues.tsx
+++ b/test/typetests/connect-options-and-issues.tsx
@@ -802,7 +802,7 @@ function testRef() {
   ></ConnectedForwardedFunctionalComponent>
 
   // Should be able to use all refs including legacy string
-  const classLegacyRef: React.LegacyRef<ClassComponent> | undefined = undefined
+  const classLegacyRef: React.Ref<ClassComponent> | undefined = undefined
   ;<ConnectedClassComponent ref={classLegacyRef}></ConnectedClassComponent>
   ;<ConnectedClassComponent
     ref={React.createRef<ClassComponent>()}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2355,41 +2355,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*":
-  version: 15.7.4
-  resolution: "@types/prop-types@npm:15.7.4"
-  checksum: 10/ef6e1899e59b876c273811b1bd845022fc66d5a3d11cb38a25b6c566b30514ae38fe20a40f67622f362a4f4f7f9224e22d8da101cff3d6e97e11d7b4c307cfc1
-  languageName: node
-  linkType: hard
-
-"@types/react-dom@npm:^18.0.0":
-  version: 18.2.18
-  resolution: "@types/react-dom@npm:18.2.18"
+"@types/react-dom@npm:types-react-dom@19.0.0-alpha.2":
+  version: 19.0.0-alpha.2
+  resolution: "types-react-dom@npm:19.0.0-alpha.2"
   dependencies:
     "@types/react": "npm:*"
-  checksum: 10/4ef7725b4cebd4a32e049097ddfdfd855a178e63ead97ab6d3084872e7d6c1acd71aa923488123cd1015f0e0b11489d2b44f674a1df8fe82d7827eabbec6dbf1
+  checksum: 10/8eab207af2c76789bddb42791cd659144e09165d72a35b13623e3c0cf619cef0e9586b94e5a866778cba7d2f404526822503de4ddbbcf24891af3f507430f0f1
   languageName: node
   linkType: hard
 
-"@types/react@npm:*":
-  version: 18.2.41
-  resolution: "@types/react@npm:18.2.41"
+"@types/react@npm:types-react@19.0.0-alpha.2":
+  version: 19.0.0-alpha.2
+  resolution: "types-react@npm:19.0.0-alpha.2"
   dependencies:
-    "@types/prop-types": "npm:*"
     "@types/scheduler": "npm:*"
     csstype: "npm:^3.0.2"
-  checksum: 10/31a498a56ad3e825ae13799355fe49042c0cdbbe6f40003f39b6b9cf847ba1669393c22ba60e97b1072cf1c002b15432082cdd17e47c948430bdc1f0864829b9
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:18.2.25":
-  version: 18.2.25
-  resolution: "@types/react@npm:18.2.25"
-  dependencies:
-    "@types/prop-types": "npm:*"
-    "@types/scheduler": "npm:*"
-    csstype: "npm:^3.0.2"
-  checksum: 10/e777471a58bde47a710c7a1906eb9fcafa793671179fc9c0187694f916da043adac5ebd4b87c8cc14c42fd4979376e7a6acabae02b99450c2a5e198155880161
+  checksum: 10/165c61c0d0e9c2679534ff9ea6711712153c6df17633b9527cca2540adfe330c5eca54800fd97db2755fb8caa25e9d48d73d5626ee05a54563e7cc725f354f6f
   languageName: node
   linkType: hard
 
@@ -7131,7 +7112,7 @@ __metadata:
     "@testing-library/react": "npm:^14.1.2"
     "@testing-library/react-hooks": "npm:^8.0.1"
     "@types/node": "npm:^20.11.6"
-    "@types/react": "npm:18.2.25"
+    "@types/react": "npm:types-react@19.0.0-alpha.2"
     "@types/use-sync-external-store": "npm:^0.0.3"
     "@typescript-eslint/eslint-plugin": "npm:^6.17.0"
     "@typescript-eslint/parser": "npm:^6.17.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2355,6 +2355,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prop-types@npm:^15.7.12":
+  version: 15.7.12
+  resolution: "@types/prop-types@npm:15.7.12"
+  checksum: 10/ac16cc3d0a84431ffa5cfdf89579ad1e2269549f32ce0c769321fdd078f84db4fbe1b461ed5a1a496caf09e637c0e367d600c541435716a55b1d9713f5035dfe
+  languageName: node
+  linkType: hard
+
 "@types/react-dom@npm:types-react-dom@19.0.0-alpha.2":
   version: 19.0.0-alpha.2
   resolution: "types-react-dom@npm:19.0.0-alpha.2"
@@ -7112,6 +7119,7 @@ __metadata:
     "@testing-library/react": "npm:^14.1.2"
     "@testing-library/react-hooks": "npm:^8.0.1"
     "@types/node": "npm:^20.11.6"
+    "@types/prop-types": "npm:^15.7.12"
     "@types/react": "npm:types-react@19.0.0-alpha.2"
     "@types/use-sync-external-store": "npm:^0.0.3"
     "@typescript-eslint/eslint-plugin": "npm:^6.17.0"


### PR DESCRIPTION
Closes https://github.com/eps1lon/DefinitelyTyped/issues/28

New bug discovered that we flush out in React 19: Implicit dependency on `@types/prop-types`. You always need to declare dependencies explicitly. Transitive dependencies are an implementation detail that can change at any time.